### PR TITLE
Fix GitHub and npm capitalization

### DIFF
--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   npm_audit:
     runs-on: ubuntu-latest
-    name: NPM Audit
+    name: npm audit
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ A Doppler Service Account allows for a configurable set of permissions to servic
 
 [Identities](https://docs.doppler.com/docs/service-account-identities) allow a service account to authenticate to Doppler via OIDC without using a static API token. This method works like the Service Account Token method below but without a static API token.
 
-The `auth-method`, `doppler-identity-id`, `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Identity. The permission `id-token: write` is required so that Doppler can obtain an OIDC token from Github for authentication.
+The `auth-method`, `doppler-identity-id`, `doppler-project` and `doppler-config` inputs must be provided when using a Service Account Identity. The permission `id-token: write` is required so that Doppler can obtain an OIDC token from GitHub for authentication.
 
 ```yaml
 jobs:
   your-example-job:
     permissions:
-      id-token: write # required for obtaining the OIDC JWT from Github
+      id-token: write # required for obtaining the OIDC JWT from GitHub
     steps:
       - uses: dopplerhq/secrets-fetch-action@v1.3.0
           id: doppler

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: >- 
       Auth method to use.
       - "token" (default): Authenticate with a static API token (`doppler-token`)
-      - "oidc": Authenticate via OIDC. Note that this requires the `id-token: write` permission on the Github job or workflow. See https://docs.doppler.com/docs/service-account-identities
+      - "oidc": Authenticate via OIDC. Note that this requires the `id-token: write` permission on the GitHub job or workflow. See https://docs.doppler.com/docs/service-account-identities
     default: "token"
   doppler-token:
     description: >-


### PR DESCRIPTION
Tiny capitalization fixes:

- `Github` -> `GitHub`
- `NPM` -> `npm` ([npm should never be capitalized](https://github.com/npm/cli#is-it-npm-or-npm-or-npm))

It would be great if someone could also update and fix the [Doppler GitHub application](https://github.com/apps/doppler-secretops-platform/) description here:

<img width="1088" height="521" src="https://github.com/user-attachments/assets/d4c8b51d-fc98-4205-b6d2-1c5f26fe3097" />
