### PR TITLE
BREAKING CHANGE: Update node to v24

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -68,4 +68,4 @@ jobs:
       #   ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/scanners.yml
+++ b/.github/workflows/scanners.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: NPM Audit
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - name: npm audit
         run: npm audit --omit dev
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Semgrep
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Scan
         id: scan
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
   service-token-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm run test
         env:
@@ -18,10 +18,10 @@ jobs:
   service-account-token-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
       - run: npm install
       - run: npm run test
         env:

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,5 @@ inputs:
     default: "api.doppler.com"
     required: false
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.1.3",
+    "version": "1.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "doppler-secrets-fetch-github-action",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows and configuration to use the latest versions of key dependencies and runtime environments. The changes ensure that CI jobs run on newer versions of Node.js and GitHub Actions, which improves security and compatibility with modern tooling.

**CI/CD Dependency Upgrades:**

* Updated `actions/checkout` from version `v4` to `v6` in both `.github/workflows/codeql-analysis.yml` and `.github/workflows/test.yml` to use the latest stable version. [[1]](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L41-R41) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-R12) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R24)
* Updated `actions/setup-node` from version `v4` to `v6` in `.github/workflows/test.yml` for both test jobs. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-R12) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R24)

**Node.js Version Upgrades:**

* Increased the Node.js version from `20` to `24` in the test workflow jobs (`service-token-test` and `service-account-token-test`) to leverage the latest Node.js features and security updates. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L9-R12) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L21-R24)
* Updated the runtime in `action.yml` from `node20` to `node24` to match the workflow changes and ensure consistency.

Due to 
[upcoming deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)


⚠️ Should be considered as breaking as requires GitHub runner ([v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1)) ⚠️